### PR TITLE
fix: migrate commands

### DIFF
--- a/docs/controller/create-controller.mdx
+++ b/docs/controller/create-controller.mdx
@@ -15,7 +15,7 @@ yarn dev # all
 
 ## Creation and automatic generation of directories
 
-Now that we're ready, let's create a `memo/` file in `server/api/`.
+Now that we're ready, let's create a `memo/` directory in `server/api/`.
 
 Then three files, `index.ts` `$relay.ts` and the main one, `controller.ts`, are automatically generated under the directory we just created.
 

--- a/docs/orm/prisma.mdx
+++ b/docs/orm/prisma.mdx
@@ -45,14 +45,14 @@ import TabItem from '@theme/TabItem';
 <TabItem value="npm">
 
 ```sh
-npm run migrate
+npm run migrate:dev
 ```
 
 </TabItem>
 <TabItem value="yarn">
 
 ```sh
-yarn migrate
+yarn migrate:dev
 ```
 
 </TabItem>


### PR DESCRIPTION
Thank you for the amazing product :smile: 

When I tried commands in this doc, I got an error.
So I updated as below :memo: 

- fix command to match "scripts" in package.json
- fix a typo in another section
